### PR TITLE
[patch] Fixed bot sends the message instead of not being able to reply

### DIFF
--- a/bot/cogs/moderation.py
+++ b/bot/cogs/moderation.py
@@ -101,7 +101,7 @@ class Moderation(BetterCog):
         channel = ctx.message.channel
         await ctx.message.delete()
         deleted_messages = len(await channel.purge(limit=num_messages))
-        await ctx.reply(
+        await ctx.send(
             f"`{deleted_messages} messages has been deleted!`", delete_after=5
         )
 


### PR DESCRIPTION
```diff
- await ctx.reply(
            f"`{deleted_messages} messages has been deleted!`", delete_after=5
        )
+ await ctx.send(
            f"`{deleted_messages} messages has been deleted!`", delete_after=5
        )